### PR TITLE
fix(pwa): update player removal logic and associated logics

### DIFF
--- a/src/components/player/PlayerManagement.tsx
+++ b/src/components/player/PlayerManagement.tsx
@@ -93,12 +93,12 @@ const UserManagement: React.FC<UserManagementProps> = ({
       onClick={onClose}
     >
       <div
-        className="relative my-6 ml-auto w-full max-w-xs overflow-y-auto overscroll-contain rounded-lg bg-white p-6 shadow-lg sm:mr-auto sm:max-w-md"
+        className="relative ml-auto w-full max-w-xs overflow-y-auto overscroll-contain rounded-l-lg bg-white p-6 shadow-lg sm:my-6 sm:mr-auto sm:max-w-md sm:rounded-r-lg"
         onClick={(e) => e.stopPropagation()}
       >
         <button
           title="Close"
-          className="absolute right-4 top-4 text-gray-400 hover:text-gray-600"
+          className="absolute right-4 top-4 text-gray-400 hover:text-gray-600 active:rounded-full active:bg-gray-300"
           onClick={onClose}
         >
           <X size="1.5em" />

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -11,7 +11,7 @@ export interface Player {
   name: string;
   index: number;
   queueNumber: string;
-  status: "available" | "unavailable";
+  status: "available" | "unavailable" | "playing" | "retired";
   partnerId?: string;
 }
 


### PR DESCRIPTION
Context:
Removing a player from the list of players affects deeply baked logic in the following areas:
- Adding players to pool
- Starting a game
- Finishing a game

These logics rely on `Player.index` property that represents the order when they are added to the pool.

Solution:
Introduce 2 additional player statuses: "playing" and "retired".

Key Status Transitions:
- When starting game: available → playing
- When deleting player: Current status → retired
- When releasing court: playing → available
